### PR TITLE
feat: Docker開発環境の完全自動化（composer/PHPMailer/必要拡張/メールテストMailHog含む）

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,28 @@
 FROM php:8.1-apache
 
-# 必要なパッケージをインストール
-RUN apt-get update && apt-get install -y \
-    libzip-dev \
-    zip \
-    unzip \
-    && docker-php-ext-install pdo pdo_mysql zip
+# 必要なパッケージ・拡張をインストール
+RUN apt-get update && \
+    apt-get install -y unzip git libzip-dev && \
+    docker-php-ext-install zip pdo pdo_mysql
 
-# Apache設定
+# Composerインストール
+RUN curl -sS https://getcomposer.org/installer | php && \
+    mv composer.phar /usr/local/bin/composer
+
+# Apacheのmod_rewrite有効化
 RUN a2enmod rewrite
 
-# 作業ディレクトリを設定
-WORKDIR /var/www
+# ドキュメントルート設定
+ENV APACHE_DOCUMENT_ROOT /var/www/html
 
-# ファイルのコピー
-COPY ../public /var/www/html
+# PHPMailerをcomposerでインストール
+WORKDIR /var/www/html
+COPY docker/composer.json composer.json
+RUN composer install
+
+# src, publicディレクトリをイメージに含める（初回ビルド用）
 COPY ../src /var/www/src
+COPY ../public /var/www/html
 
 # 権限設定
 RUN chown -R www-data:www-data /var/www

--- a/docker/composer.json
+++ b/docker/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "phpmailer/phpmailer": "^6.10"
+  }
+} 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.8'
 
 services:
   web:
-    image: php:8.1-apache
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     ports:
       - "8080:80"
     volumes:
@@ -14,10 +16,6 @@ services:
       - APACHE_DOCUMENT_ROOT=/var/www/html
     networks:
       - app-network
-    command: >
-      sh -c "a2enmod rewrite &&
-             docker-php-ext-install pdo pdo_mysql &&
-             apache2-foreground"
 
   db:
     image: mysql:8.0
@@ -31,6 +29,14 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
       - ../database/schema:/docker-entrypoint-initdb.d
+    networks:
+      - app-network
+
+  mailhog:
+    image: mailhog/mailhog:latest
+    ports:
+      - "1025:1025"
+      - "8025:8025"
     networks:
       - app-network
 


### PR DESCRIPTION
## 概要
- Dockerfileでwebサービスにcomposer, unzip, php-zip, libzip-dev, PHPMailerを自動導入
- docker/composer.jsonでPHPMailerをcomposer管理
- docker-compose.ymlでwebサービスをbuild化、MailHogサービスも追加
- docker-compose upだけでweb/db/mailhogが自動起動し、追加セットアップ不要
- 問い合わせ機能のメール送信もMailHogでテスト可能
- 本番SMTP切替も容易な構成に

## 変更詳細
- Dockerfile: 必要パッケージ拡張composerPHPMailer自動導入、src/publicのCOPY
- docker/composer.json: PHPMailerのみrequire
- docker-compose.yml: webサービスをbuild化、MailHogサービス追加、ボリュームネットワーク設定
- これにより、初回セットアップや環境再現が大幅に簡素化
- MailHogのWeb UI（http://localhost:8025）でメール送信テストが容易

## 今後の運用
- 本番SMTP利用時はMailConfigのSMTP設定を切り替えるだけで対応可能
- 開発者はdocker-compose upのみで全環境を再現可能

